### PR TITLE
Credit bitmap arcade rips

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This repo contains all of the custom fonts for the MiSTer FPGA project. You can view the previews of the fonts below. A Pixelfont editor such as [8x8 Pixel ROM Font Editor](https://www.min.at/prinz/o/software/pixelfont/) by Richard Prinz can be used to generate your own, or you can edit them via the txt files in `./src/txt`. If you are interested in contributing, the tools folder has scripts to generate the pf files from text or to convert the pf files to png previews and more.
+This repo contains all of the custom fonts for the MiSTer FPGA project. You can view the previews of the fonts below. A Pixelfont editor such as [8x8 Pixel ROM Font Editor](https://www.min.at/prinz/o/software/pixelfont/) by Richard Prinz can be used to generate your own, or you can edit them via the txt files in `./src/txt`. If you are interested in contributing, the tools folder has scripts to generate the pf files from text or to convert the pf files to png previews and more. Many included bitmaps are derived from the arcade sources collected by [NFG](https://nfgworld.com/arcade-fonts-only-64-pixels/).
 
 ### Arcade_Aero_Fighters_(Kaneko)
 ![Arcade_Aero_Fighters_(Kaneko)](https://github.com/MiSTer-devel/Fonts_MiSTer/raw/master/preview2/Arcade_Aero_Fighters_(Kaneko).png)<br />


### PR DESCRIPTION
A ton of the arcade fonts were haphazardly pulled from NFGworld by Rikard Bengtsson in early commits. I cleaned up a lot of incorrectly copied character sets in an earlier PR, but I think it's considerate to credit the original compiler of these sources as well, and point to the bitmap rips for posterity.

NFG is neither author nor rights holder of the art and has seemed happy enough to have them distributed in the MiSTer project where it's been discussed, but acknowledging these were pulled from his collection seems polite.